### PR TITLE
Bump Rust Docker base image to 1.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91
+FROM rust:1.96
 
 WORKDIR /usr/src/prom-money-rs
 COPY . .


### PR DESCRIPTION
Mechanical bump of the Dockerfile `FROM rust:1.X` base image to `rust:1.96`. No source changes; toolchain bump only.

Part of kj800x/homelab#3.