### PR TITLE
Convert Dockerfile to multi-stage build with dep caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,24 @@
-FROM rust:1.96
+# Build Stage
+FROM rust:1.96 AS builder
 
+WORKDIR /usr/src
+RUN USER=root cargo new --vcs none prom-money-rs
 WORKDIR /usr/src/prom-money-rs
-COPY . .
 
-RUN cargo install --path .
+# Pre-cache dependencies
+COPY Cargo.toml Cargo.lock ./
+RUN cargo build --release
+
+# Copy actual source and rebuild
+COPY src ./src
+RUN touch src/main.rs && cargo build --release
+
+# Runtime Stage
+FROM debian:trixie-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/prom-money-rs/target/release/prom-money-rs /usr/local/bin/prom-money-rs
 
 CMD ["prom-money-rs"]


### PR DESCRIPTION
Was a single-stage `FROM rust:1.96` + `COPY . .` + `cargo install --path .` build, which invalidated the dep cache on any source change. Converted to the same two-stage pattern as cicd / heartbeat-rs / webhooks-enforcer:

- Builder stage pre-caches deps via `cargo new` + `COPY Cargo.toml Cargo.lock` + `cargo build --release`
- Runtime stage is `debian:trixie-slim` (matches the rust:1.96 image's distro) with `ca-certificates` and `libssl3`

Validated locally with `docker build` on Rust 1.96; binary runs.

Part of kj800x/homelab#5.